### PR TITLE
Switch diff highlight to background

### DIFF
--- a/colors/catppuccin_frappe.vim
+++ b/colors/catppuccin_frappe.vim
@@ -50,10 +50,10 @@ hi CursorIM         guisp=NONE      guifg=#303446   guibg=#C6D0F5   ctermfg=235 
 hi CursorColumn     guisp=NONE      guifg=NONE      guibg=#292C3C   ctermfg=NONE    ctermbg=234  gui=NONE           cterm=NONE
 hi CursorLine       guisp=NONE      guifg=NONE      guibg=#414559   ctermfg=NONE    ctermbg=236  gui=NONE           cterm=NONE
 hi Directory        guisp=NONE      guifg=#8CAAEE   guibg=NONE      ctermfg=117     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffAdd          guisp=NONE      guifg=#A6D189   guibg=NONE      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffChange       guisp=NONE      guifg=#E5C890   guibg=NONE      ctermfg=223     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffDelete       guisp=NONE      guifg=#E78284   guibg=NONE      ctermfg=211     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffText         guisp=NONE      guifg=#8CAAEE   guibg=#303446   ctermfg=117     ctermbg=235  gui=NONE           cterm=NONE
+hi DiffAdd          guisp=NONE      guifg=#303446   guibg=#A6D189      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
+hi DiffChange       guisp=NONE      guifg=#303446   guibg=#E5C890      ctermfg=223     ctermbg=NONE gui=NONE           cterm=NONE
+hi DiffDelete       guisp=NONE      guifg=#303446   guibg=#E78284      ctermfg=211     ctermbg=NONE gui=NONE           cterm=NONE
+hi DiffText         guisp=NONE      guifg=#303446   guibg=#8CAAEE   ctermfg=117     ctermbg=235  gui=NONE           cterm=NONE
 hi EndOfBuffer      guisp=NONE      guifg=NONE      guibg=NONE      ctermfg=NONE    ctermbg=NONE gui=NONE           cterm=NONE
 hi ErrorMsg         guisp=NONE      guifg=#E78284   guibg=NONE      ctermfg=211     ctermbg=NONE gui=bold,italic    cterm=bold,italic
 hi VertSplit        guisp=NONE      guifg=#232634   guibg=NONE      ctermfg=234     ctermbg=NONE gui=NONE           cterm=NONE

--- a/colors/catppuccin_latte.vim
+++ b/colors/catppuccin_latte.vim
@@ -50,10 +50,10 @@ hi CursorIM         guisp=NONE      guifg=#EFF1F5   guibg=#4C4F69   ctermfg=235 
 hi CursorColumn     guisp=NONE      guifg=NONE      guibg=#E6E9EF   ctermfg=NONE    ctermbg=234  gui=NONE           cterm=NONE
 hi CursorLine       guisp=NONE      guifg=NONE      guibg=#CCD0DA   ctermfg=NONE    ctermbg=236  gui=NONE           cterm=NONE
 hi Directory        guisp=NONE      guifg=#1e66f5   guibg=NONE      ctermfg=117     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffAdd          guisp=NONE      guifg=#40A02B   guibg=NONE      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffChange       guisp=NONE      guifg=#df8e1d   guibg=NONE      ctermfg=223     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffDelete       guisp=NONE      guifg=#D20F39   guibg=NONE      ctermfg=211     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffText         guisp=NONE      guifg=#1e66f5   guibg=#EFF1F5   ctermfg=117     ctermbg=235  gui=NONE           cterm=NONE
+hi DiffAdd          guisp=NONE      guifg=#EFF1F5   guibg=#40A02B      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
+hi DiffChange       guisp=NONE      guifg=#EFF1F5   guibg=#df8e1d      ctermfg=223     ctermbg=NONE gui=NONE           cterm=NONE
+hi DiffDelete       guisp=NONE      guifg=#EFF1F5   guibg=#D20F39      ctermfg=211     ctermbg=NONE gui=NONE           cterm=NONE
+hi DiffText         guisp=NONE      guifg=#EFF1F5   guibg=#1e66f5   ctermfg=117     ctermbg=235  gui=NONE           cterm=NONE
 hi EndOfBuffer      guisp=NONE      guifg=NONE      guibg=NONE      ctermfg=NONE    ctermbg=NONE gui=NONE           cterm=NONE
 hi ErrorMsg         guisp=NONE      guifg=#D20F39   guibg=NONE      ctermfg=211     ctermbg=NONE gui=bold,italic    cterm=bold,italic
 hi VertSplit        guisp=NONE      guifg=#DCE0E8   guibg=NONE      ctermfg=234     ctermbg=NONE gui=NONE           cterm=NONE

--- a/colors/catppuccin_macchiato.vim
+++ b/colors/catppuccin_macchiato.vim
@@ -50,10 +50,10 @@ hi CursorIM         guisp=NONE      guifg=#24273A   guibg=#CAD3F5   ctermfg=235 
 hi CursorColumn     guisp=NONE      guifg=NONE      guibg=#1E2030   ctermfg=NONE    ctermbg=234  gui=NONE           cterm=NONE
 hi CursorLine       guisp=NONE      guifg=NONE      guibg=#363A4F   ctermfg=NONE    ctermbg=236  gui=NONE           cterm=NONE
 hi Directory        guisp=NONE      guifg=#8AADF4   guibg=NONE      ctermfg=117     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffAdd          guisp=NONE      guifg=#A6DA95   guibg=NONE      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffChange       guisp=NONE      guifg=#EED49F   guibg=NONE      ctermfg=223     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffDelete       guisp=NONE      guifg=#ED8796   guibg=NONE      ctermfg=211     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffText         guisp=NONE      guifg=#8AADF4   guibg=#24273A   ctermfg=117     ctermbg=235  gui=NONE           cterm=NONE
+hi DiffAdd          guisp=NONE      guifg=#24273A   guibg=#A6DA95      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
+hi DiffChange       guisp=NONE      guifg=#24273A   guibg=#EED49F      ctermfg=223     ctermbg=NONE gui=NONE           cterm=NONE
+hi DiffDelete       guisp=NONE      guifg=#24273A   guibg=#ED8796      ctermfg=211     ctermbg=NONE gui=NONE           cterm=NONE
+hi DiffText         guisp=NONE      guifg=#24273A   guibg=#8AADF4   ctermfg=117     ctermbg=235  gui=NONE           cterm=NONE
 hi EndOfBuffer      guisp=NONE      guifg=NONE      guibg=NONE      ctermfg=NONE    ctermbg=NONE gui=NONE           cterm=NONE
 hi ErrorMsg         guisp=NONE      guifg=#ED8796   guibg=NONE      ctermfg=211     ctermbg=NONE gui=bold,italic    cterm=bold,italic
 hi VertSplit        guisp=NONE      guifg=#181926   guibg=NONE      ctermfg=234     ctermbg=NONE gui=NONE           cterm=NONE

--- a/colors/catppuccin_mocha.vim
+++ b/colors/catppuccin_mocha.vim
@@ -50,10 +50,10 @@ hi CursorIM         guisp=NONE      guifg=#1E1E2E   guibg=#CDD6F4   ctermfg=235 
 hi CursorColumn     guisp=NONE      guifg=NONE      guibg=#181825   ctermfg=NONE    ctermbg=234  gui=NONE           cterm=NONE
 hi CursorLine       guisp=NONE      guifg=NONE      guibg=#313244   ctermfg=NONE    ctermbg=236  gui=NONE           cterm=NONE
 hi Directory        guisp=NONE      guifg=#89B4FA   guibg=NONE      ctermfg=117     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffAdd          guisp=NONE      guifg=#A6E3A1   guibg=NONE      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffChange       guisp=NONE      guifg=#F9E2AF   guibg=NONE      ctermfg=223     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffDelete       guisp=NONE      guifg=#F38BA8   guibg=NONE      ctermfg=211     ctermbg=NONE gui=NONE           cterm=NONE
-hi DiffText         guisp=NONE      guifg=#89B4FA   guibg=#1E1E2E   ctermfg=117     ctermbg=235  gui=NONE           cterm=NONE
+hi DiffAdd          guisp=NONE      guifg=#1E1E2E   guibg=#A6E3A1   ctermfg=235     ctermbg=151  gui=NONE           cterm=NONE
+hi DiffChange       guisp=NONE      guifg=#1E1E2E   guibg=#F9E2AF   ctermfg=235     ctermbg=223 gui=NONE           cterm=NONE
+hi DiffDelete       guisp=NONE      guifg=#1E1E2E   guibg=#F38BA8   ctermfg=235     ctermbg=211 gui=NONE           cterm=NONE
+hi DiffText         guisp=NONE      guifg=#1E1E2E   guibg=#89B4FA   ctermfg=235     ctermbg=117 gui=NONE           cterm=NONE
 hi EndOfBuffer      guisp=NONE      guifg=NONE      guibg=NONE      ctermfg=NONE    ctermbg=NONE gui=NONE           cterm=NONE
 hi ErrorMsg         guisp=NONE      guifg=#F38BA8   guibg=NONE      ctermfg=211     ctermbg=NONE gui=bold,italic    cterm=bold,italic
 hi VertSplit        guisp=NONE      guifg=#11111B   guibg=NONE      ctermfg=234     ctermbg=NONE gui=NONE           cterm=NONE


### PR DESCRIPTION
Hi, a quick PR to change how diff split colors appear. Currently, only the font color shows the difference, which isn't really easy to follow. This commit aims at switching font color with background color, similar to the visuals of the nvim plugin.

Before
![diff_before](https://user-images.githubusercontent.com/28339661/176941702-24b75c4a-3ae9-49ea-9b96-b28776968f5d.png)

After
![diff_after](https://user-images.githubusercontent.com/28339661/176941695-8126bda4-52bc-4501-9944-d162e329693e.png)