### PR TITLE
Add lightline colortheme

### DIFF
--- a/autoload/lightline/colorscheme/catppuccin_frappe.vim
+++ b/autoload/lightline/colorscheme/catppuccin_frappe.vim
@@ -1,0 +1,36 @@
+" =============================================================================
+" Filename: autoload/lightline/colorscheme/catppuccin_frappe.vim
+" Author: maxjcohen
+" License: MIT License
+" Last Change: 2022/07/16
+" =============================================================================
+
+let s:mauve = [ "#CA9EE6", 183 ]
+let s:red = [ "#E78284", 211 ]
+let s:yellow = [ "#E5C890", 223 ]
+let s:teal = [ "#81C8BE", 152 ]
+let s:blue = [ "#8CAAEE", 117 ]
+let s:overlay0 = [ "#737994", 243 ]
+let s:surface1 = [ "#51576D", 240 ]
+let s:surface0 = [ "#414559", 236 ]
+let s:base = [ "#303446", 235 ]
+let s:mantle = [ "#292C3C", 234 ]
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:mantle, s:blue ], [ s:blue, s:base ] ]
+let s:p.normal.right = [ [ s:overlay0, s:base ], [ s:blue, s:surface0 ] ]
+let s:p.inactive.right = [ [ s:surface1, s:base ], [ s:overlay0, s:base ] ]
+let s:p.inactive.left =  [ [ s:blue, s:base ], [ s:overlay0, s:base ] ]
+let s:p.insert.left = [ [ s:mantle, s:teal ], [ s:blue, s:base ] ]
+let s:p.replace.left = [ [ s:mantle, s:red ], [ s:blue, s:base ] ]
+let s:p.visual.left = [ [ s:mantle, s:mauve ], [ s:blue, s:base ] ]
+let s:p.normal.middle = [ [ s:blue, s:surface1 ] ]
+let s:p.inactive.middle = [ [ s:surface1, s:base ] ]
+let s:p.tabline.left = [ [ s:overlay0, s:base ], [ s:overlay0, s:base ] ]
+let s:p.tabline.tabsel = [ [ s:blue, s:surface1 ], [ s:overlay0, s:base] ]
+let s:p.tabline.middle = [ [ s:surface1, s:base ] ]
+let s:p.tabline.right = copy(s:p.inactive.right)
+let s:p.normal.error = [ [ s:mantle, s:red ] ]
+let s:p.normal.warning = [ [ s:mantle, s:yellow ] ]
+
+let g:lightline#colorscheme#catppuccin_frappe#palette = lightline#colorscheme#flatten(s:p)

--- a/autoload/lightline/colorscheme/catppuccin_latte.vim
+++ b/autoload/lightline/colorscheme/catppuccin_latte.vim
@@ -1,0 +1,36 @@
+" =============================================================================
+" Filename: autoload/lightline/colorscheme/catppuccin_latte.vim
+" Author: maxjcohen
+" License: MIT License
+" Last Change: 2022/07/16
+" =============================================================================
+
+let s:mauve = [ "#8839EF", 183 ]
+let s:red = [ "#D20F39", 211 ]
+let s:yellow = [ "#DF8E1D", 223 ]
+let s:teal = [ "#179299", 152 ]
+let s:blue = [ "#1E66F5", 117 ]
+let s:overlay0 = [ "#9CA0B0", 243 ]
+let s:surface1 = [ "#BCC0CC", 240 ]
+let s:surface0 = [ "#CCD0DA", 236 ]
+let s:base = [ "#EFF1F5", 235 ]
+let s:mantle = [ "#E6E9EF", 234 ]
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:mantle, s:blue ], [ s:blue, s:base ] ]
+let s:p.normal.right = [ [ s:overlay0, s:base ], [ s:blue, s:surface0 ] ]
+let s:p.inactive.right = [ [ s:surface1, s:base ], [ s:overlay0, s:base ] ]
+let s:p.inactive.left =  [ [ s:blue, s:base ], [ s:overlay0, s:base ] ]
+let s:p.insert.left = [ [ s:mantle, s:teal ], [ s:blue, s:base ] ]
+let s:p.replace.left = [ [ s:mantle, s:red ], [ s:blue, s:base ] ]
+let s:p.visual.left = [ [ s:mantle, s:mauve ], [ s:blue, s:base ] ]
+let s:p.normal.middle = [ [ s:blue, s:surface1 ] ]
+let s:p.inactive.middle = [ [ s:surface1, s:base ] ]
+let s:p.tabline.left = [ [ s:overlay0, s:base ], [ s:overlay0, s:base ] ]
+let s:p.tabline.tabsel = [ [ s:blue, s:surface1 ], [ s:overlay0, s:base] ]
+let s:p.tabline.middle = [ [ s:surface1, s:base ] ]
+let s:p.tabline.right = copy(s:p.inactive.right)
+let s:p.normal.error = [ [ s:mantle, s:red ] ]
+let s:p.normal.warning = [ [ s:mantle, s:yellow ] ]
+
+let g:lightline#colorscheme#catppuccin_latte#palette = lightline#colorscheme#flatten(s:p)

--- a/autoload/lightline/colorscheme/catppuccin_macchiato.vim
+++ b/autoload/lightline/colorscheme/catppuccin_macchiato.vim
@@ -1,0 +1,36 @@
+" =============================================================================
+" Filename: autoload/lightline/colorscheme/catppuccin_macchiato.vim
+" Author: maxjcohen
+" License: MIT License
+" Last Change: 2022/07/16
+" =============================================================================
+
+let s:mauve = [ "#C6A0F6", 183 ]
+let s:red = [ "#ED8796", 211 ]
+let s:yellow = [ "#EED49F", 223 ]
+let s:teal = [ "#8BD5CA", 152 ]
+let s:blue = [ "#8AADF4", 117 ]
+let s:overlay0 = [ "#6E738D", 243 ]
+let s:surface1 = [ "#494D64", 240 ]
+let s:surface0 = [ "#363A4F", 236 ]
+let s:base = [ "#24273A", 235 ]
+let s:mantle = [ "#1E2030", 234 ]
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:mantle, s:blue ], [ s:blue, s:base ] ]
+let s:p.normal.right = [ [ s:overlay0, s:base ], [ s:blue, s:surface0 ] ]
+let s:p.inactive.right = [ [ s:surface1, s:base ], [ s:overlay0, s:base ] ]
+let s:p.inactive.left =  [ [ s:blue, s:base ], [ s:overlay0, s:base ] ]
+let s:p.insert.left = [ [ s:mantle, s:teal ], [ s:blue, s:base ] ]
+let s:p.replace.left = [ [ s:mantle, s:red ], [ s:blue, s:base ] ]
+let s:p.visual.left = [ [ s:mantle, s:mauve ], [ s:blue, s:base ] ]
+let s:p.normal.middle = [ [ s:blue, s:surface1 ] ]
+let s:p.inactive.middle = [ [ s:surface1, s:base ] ]
+let s:p.tabline.left = [ [ s:overlay0, s:base ], [ s:overlay0, s:base ] ]
+let s:p.tabline.tabsel = [ [ s:blue, s:surface1 ], [ s:overlay0, s:base] ]
+let s:p.tabline.middle = [ [ s:surface1, s:base ] ]
+let s:p.tabline.right = copy(s:p.inactive.right)
+let s:p.normal.error = [ [ s:mantle, s:red ] ]
+let s:p.normal.warning = [ [ s:mantle, s:yellow ] ]
+
+let g:lightline#colorscheme#catppuccin_macchiato#palette = lightline#colorscheme#flatten(s:p)

--- a/autoload/lightline/colorscheme/catppuccin_mocha.vim
+++ b/autoload/lightline/colorscheme/catppuccin_mocha.vim
@@ -1,0 +1,36 @@
+" =============================================================================
+" Filename: autoload/lightline/colorscheme/catppuccin_mocha.vim
+" Author: maxjcohen
+" License: MIT License
+" Last Change: 2022/07/16
+" =============================================================================
+
+let s:mauve = [ "#CBA6F7", 183 ]
+let s:red = [ "#F38BA8", 211 ]
+let s:yellow = [ "#F9E2AF", 223 ]
+let s:teal = [ "#94E2D5", 152 ]
+let s:blue = [ "#89B4FA", 117 ]
+let s:overlay0 = [ "#6C7086", 243 ]
+let s:surface1 = [ "#45475A", 240 ]
+let s:surface0 = [ "#313244", 236 ]
+let s:base = [ "#1E1E2E", 235 ]
+let s:mantle = [ "#181825", 234 ]
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:mantle, s:blue ], [ s:blue, s:base ] ]
+let s:p.normal.right = [ [ s:overlay0, s:base ], [ s:blue, s:surface0 ] ]
+let s:p.inactive.right = [ [ s:surface1, s:base ], [ s:overlay0, s:base ] ]
+let s:p.inactive.left =  [ [ s:blue, s:base ], [ s:overlay0, s:base ] ]
+let s:p.insert.left = [ [ s:mantle, s:teal ], [ s:blue, s:base ] ]
+let s:p.replace.left = [ [ s:mantle, s:red ], [ s:blue, s:base ] ]
+let s:p.visual.left = [ [ s:mantle, s:mauve ], [ s:blue, s:base ] ]
+let s:p.normal.middle = [ [ s:blue, s:surface1 ] ]
+let s:p.inactive.middle = [ [ s:surface1, s:base ] ]
+let s:p.tabline.left = [ [ s:overlay0, s:base ], [ s:overlay0, s:base ] ]
+let s:p.tabline.tabsel = [ [ s:blue, s:surface1 ], [ s:overlay0, s:base] ]
+let s:p.tabline.middle = [ [ s:surface1, s:base ] ]
+let s:p.tabline.right = copy(s:p.inactive.right)
+let s:p.normal.error = [ [ s:mantle, s:red ] ]
+let s:p.normal.warning = [ [ s:mantle, s:yellow ] ]
+
+let g:lightline#colorscheme#catppuccin_mocha#palette = lightline#colorscheme#flatten(s:p)


### PR DESCRIPTION
Hey, I've added a [lightline](https://github.com/itchyny/lightline.vim) theme, as it's the only nvim Cattpuccin statusline pluggin that also supports the old vim.