### PR TITLE
Remove LineNrAbove/Below specific colors

### DIFF
--- a/colors/catppuccin_frappe.vim
+++ b/colors/catppuccin_frappe.vim
@@ -62,8 +62,6 @@ hi FoldColumn       guisp=NONE      guifg=#737994   guibg=#303446   ctermfg=243 
 hi SignColumn       guisp=NONE      guifg=#51576D   guibg=#303446   ctermfg=240     ctermbg=235  gui=NONE           cterm=NONE
 hi IncSearch        guisp=NONE      guifg=#51576D   guibg=#F4B8E4   ctermfg=240     ctermbg=218  gui=NONE           cterm=NONE
 hi LineNr           guisp=NONE      guifg=#51576D   guibg=NONE      ctermfg=240     ctermbg=NONE gui=NONE           cterm=NONE
-hi LineNrAbove      guisp=NONE      guifg=#ffffff   guibg=NONE      ctermfg=231     ctermbg=NONE gui=NONE           cterm=NONE
-hi LineNrBelow      guisp=NONE      guifg=#ffffff   guibg=NONE      ctermfg=231     ctermbg=NONE gui=NONE           cterm=NONE
 hi CursorLineNr     guisp=NONE      guifg=#BABBF1   guibg=NONE      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
 hi MatchParen       guisp=NONE      guifg=#EF9F76   guibg=NONE      ctermfg=216     ctermbg=NONE gui=bold           cterm=bold
 hi ModeMsg          guisp=NONE      guifg=#C6D0F5   guibg=NONE      ctermfg=254     ctermbg=NONE gui=bold           cterm=bold

--- a/colors/catppuccin_latte.vim
+++ b/colors/catppuccin_latte.vim
@@ -62,8 +62,6 @@ hi FoldColumn       guisp=NONE      guifg=#9CA0B0   guibg=#EFF1F5   ctermfg=243 
 hi SignColumn       guisp=NONE      guifg=#BCC0CC   guibg=#EFF1F5   ctermfg=240     ctermbg=235  gui=NONE           cterm=NONE
 hi IncSearch        guisp=NONE      guifg=#BCC0CC   guibg=#ea76cb   ctermfg=240     ctermbg=218  gui=NONE           cterm=NONE
 hi LineNr           guisp=NONE      guifg=#BCC0CC   guibg=NONE      ctermfg=240     ctermbg=NONE gui=NONE           cterm=NONE
-hi LineNrAbove      guisp=NONE      guifg=#ffffff   guibg=NONE      ctermfg=231     ctermbg=NONE gui=NONE           cterm=NONE
-hi LineNrBelow      guisp=NONE      guifg=#ffffff   guibg=NONE      ctermfg=231     ctermbg=NONE gui=NONE           cterm=NONE
 hi CursorLineNr     guisp=NONE      guifg=#7287FD   guibg=NONE      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
 hi MatchParen       guisp=NONE      guifg=#FE640B   guibg=NONE      ctermfg=216     ctermbg=NONE gui=bold           cterm=bold
 hi ModeMsg          guisp=NONE      guifg=#4C4F69   guibg=NONE      ctermfg=254     ctermbg=NONE gui=bold           cterm=bold

--- a/colors/catppuccin_macchiato.vim
+++ b/colors/catppuccin_macchiato.vim
@@ -62,8 +62,6 @@ hi FoldColumn       guisp=NONE      guifg=#6E738D   guibg=#24273A   ctermfg=243 
 hi SignColumn       guisp=NONE      guifg=#494D64   guibg=#24273A   ctermfg=240     ctermbg=235  gui=NONE           cterm=NONE
 hi IncSearch        guisp=NONE      guifg=#494D64   guibg=#F5BDE6   ctermfg=240     ctermbg=218  gui=NONE           cterm=NONE
 hi LineNr           guisp=NONE      guifg=#494D64   guibg=NONE      ctermfg=240     ctermbg=NONE gui=NONE           cterm=NONE
-hi LineNrAbove      guisp=NONE      guifg=#ffffff   guibg=NONE      ctermfg=231     ctermbg=NONE gui=NONE           cterm=NONE
-hi LineNrBelow      guisp=NONE      guifg=#ffffff   guibg=NONE      ctermfg=231     ctermbg=NONE gui=NONE           cterm=NONE
 hi CursorLineNr     guisp=NONE      guifg=#B7BDF8   guibg=NONE      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
 hi MatchParen       guisp=NONE      guifg=#F5A97F   guibg=NONE      ctermfg=216     ctermbg=NONE gui=bold           cterm=bold
 hi ModeMsg          guisp=NONE      guifg=#CAD3F5   guibg=NONE      ctermfg=254     ctermbg=NONE gui=bold           cterm=bold

--- a/colors/catppuccin_mocha.vim
+++ b/colors/catppuccin_mocha.vim
@@ -62,8 +62,6 @@ hi FoldColumn       guisp=NONE      guifg=#6C7086   guibg=#1E1E2E   ctermfg=243 
 hi SignColumn       guisp=NONE      guifg=#45475A   guibg=#1E1E2E   ctermfg=240     ctermbg=235  gui=NONE           cterm=NONE
 hi IncSearch        guisp=NONE      guifg=#45475A   guibg=#F5C2E7   ctermfg=240     ctermbg=218  gui=NONE           cterm=NONE
 hi LineNr           guisp=NONE      guifg=#45475A   guibg=NONE      ctermfg=240     ctermbg=NONE gui=NONE           cterm=NONE
-hi LineNrAbove      guisp=NONE      guifg=#ffffff   guibg=NONE      ctermfg=231     ctermbg=NONE gui=NONE           cterm=NONE
-hi LineNrBelow      guisp=NONE      guifg=#ffffff   guibg=NONE      ctermfg=231     ctermbg=NONE gui=NONE           cterm=NONE
 hi CursorLineNr     guisp=NONE      guifg=#B4BEFE   guibg=NONE      ctermfg=151     ctermbg=NONE gui=NONE           cterm=NONE
 hi MatchParen       guisp=NONE      guifg=#FAB387   guibg=NONE      ctermfg=216     ctermbg=NONE gui=bold           cterm=bold
 hi ModeMsg          guisp=NONE      guifg=#CDD6F4   guibg=NONE      ctermfg=254     ctermbg=NONE gui=bold           cterm=bold


### PR DESCRIPTION
Hi, small PR to remove specific values for `LineNrAbove` and Below, causing `relativenumber` to appear in fixed (here white) color. By simply removing those lines, vim and nvim fall back to the `LineNr` value for `relativenumber`.