### PR TITLE
Set terminal_ansi_colors to work with plugins like fzf

### DIFF
--- a/colors/catppuccin_frappe.vim
+++ b/colors/catppuccin_frappe.vim
@@ -153,3 +153,9 @@ hi link StatusLineTerm StatusLine
 hi link StatusLineTermNC StatusLineNC
 hi link Terminal Normal
 hi link Ignore Comment
+
+" Set terminal colors for playing well with plugins like fzf
+let g:terminal_ansi_colors = [
+  \ s:surface1, s:red, s:green, s:yellow, s:blue, s:pink, s:teal, s:subtext1,
+  \ s:surface2, s:red, s:green, s:yellow, s:blue, s:pink, s:teal, s:subtext0
+\ ]

--- a/colors/catppuccin_latte.vim
+++ b/colors/catppuccin_latte.vim
@@ -153,3 +153,9 @@ hi link StatusLineTerm StatusLine
 hi link StatusLineTermNC StatusLineNC
 hi link Terminal Normal
 hi link Ignore Comment
+
+" Set terminal colors for playing well with plugins like fzf
+let g:terminal_ansi_colors = [
+  \ s:subtext1, s:red, s:green, s:yellow, s:blue, s:pink, s:teal, s:surface2,
+  \ s:subtext0, s:red, s:green, s:yellow, s:blue, s:pink, s:teal, s:surface1
+\ ]

--- a/colors/catppuccin_macchiato.vim
+++ b/colors/catppuccin_macchiato.vim
@@ -153,3 +153,9 @@ hi link StatusLineTerm StatusLine
 hi link StatusLineTermNC StatusLineNC
 hi link Terminal Normal
 hi link Ignore Comment
+
+" Set terminal colors for playing well with plugins like fzf
+let g:terminal_ansi_colors = [
+  \ s:surface1, s:red, s:green, s:yellow, s:blue, s:pink, s:teal, s:subtext1,
+  \ s:surface2, s:red, s:green, s:yellow, s:blue, s:pink, s:teal, s:subtext0
+\ ]

--- a/colors/catppuccin_mocha.vim
+++ b/colors/catppuccin_mocha.vim
@@ -153,3 +153,9 @@ hi link StatusLineTerm StatusLine
 hi link StatusLineTermNC StatusLineNC
 hi link Terminal Normal
 hi link Ignore Comment
+
+" Set terminal colors for playing well with plugins like fzf
+let g:terminal_ansi_colors = [
+  \ s:surface1, s:red, s:green, s:yellow, s:blue, s:pink, s:teal, s:subtext1,
+  \ s:surface2, s:red, s:green, s:yellow, s:blue, s:pink, s:teal, s:subtext0
+\ ]


### PR DESCRIPTION
In GUI mode/with termguicolors set, there can be colour mismatches between the terminal/GUI themes. I got this issue while using `Ag` vs `Ag!` in [fzf.vim](https://github.com/junegunn/fzf.vim). fzf [suggests fixing this](https://github.com/junegunn/fzf/blob/9ec3f0387175c6993841c69a230414f8fef00e51/README-VIM.md#fzf-inside-terminal-buffer) by setting `terminal_ansi_colors`. So I copied the 16 terminal colors into the variable with this pull request.